### PR TITLE
new approach to 3- and 4-pt cross-terms

### DIFF
--- a/micro21cm/analysis.py
+++ b/micro21cm/analysis.py
@@ -468,7 +468,7 @@ class AnalyzeFit(object): # pragma: no cover
         if use_cbar and show_cbar:
             cax = fig.add_axes([0.91, 0.11, 0.015, 0.77])
             cb = pl.colorbar(cmap, ax=ax, cax=cax, orientation='vertical')
-            cb.set_label(r'$z$')
+            cb.set_label(r'$z$', fontsize=20)
 
 
         return ax

--- a/micro21cm/analysis.py
+++ b/micro21cm/analysis.py
@@ -141,7 +141,7 @@ class AnalyzeFit(object): # pragma: no cover
     def plot_triangle(self, fig=1, axes=None, params=None, redshifts=None,
         complement=False, bins=20, burn=0, fig_kwargs={}, contours=True,
         fill=False, nu=[0.95, 0.68], take_log=False, is_log=False,
-        skip=None, smooth=None, skip_params=None, **kwargs):
+        skip=None, smooth=None, skip_params=None, show_1d=True, **kwargs):
         """
 
         """
@@ -180,8 +180,11 @@ class AnalyzeFit(object): # pragma: no cover
 
         # Remember, for gridspec, rows are numbered frop top-down.
         if not has_ax:
-            gs = fig.add_gridspec(Np, Np)
-            axes_by_row = [[] for i in range(Np)]
+            if show_1d:
+                gs = fig.add_gridspec(Np, Np)
+                axes_by_row = [[] for i in range(Np)]
+            else:
+                axes_by_row = [fig.add_subplot(111)]
 
         flatchain = self.data['flatchain']
 
@@ -191,6 +194,9 @@ class AnalyzeFit(object): # pragma: no cover
                 if j > i:
                     continue
 
+                if (not show_1d) and i == j:
+                    continue
+
                 if skip is not None:
                     if i in skip:
                         continue
@@ -198,11 +204,14 @@ class AnalyzeFit(object): # pragma: no cover
                         continue
 
                 # Create axis
-                if not has_ax:
-                    _ax = fig.add_subplot(gs[i,j])
-                    axes_by_row[i].append(_ax)
+                if show_1d:
+                    if not has_ax:
+                        _ax = fig.add_subplot(gs[i,j])
+                        axes_by_row[i].append(_ax)
+                    else:
+                        _ax = axes_by_row[i][j]
                 else:
-                    _ax = axes_by_row[i][j]
+                    _ax = axes_by_row[0]
 
                 if skip_params is not None:
                     if params[i] in skip_params:

--- a/micro21cm/inference.py
+++ b/micro21cm/inference.py
@@ -45,7 +45,7 @@ _priors_broad = \
  'Ts': (1e-2, 1000.),
  'Q': (0, 1),
  'R': (0, 100),
- 'sigma': (0.05, 2),
+ 'sigma': (0.05, 2.5),
  'gamma': (-4, 0),
  'Asys': (0.5, 1.5),
 }
@@ -520,8 +520,8 @@ class FitHelper(object):
     @property
     def func_gamma(self):
         if not hasattr(self, '_func_g'):
-            self._func_s = self.get_func('gamma')
-        return self._func_s
+            self._func_g = self.get_func('gamma')
+        return self._func_g
 
     @property
     def func_A(self):
@@ -633,8 +633,9 @@ class FitHelper(object):
 
             # Parameter not allowed to evolve with redshift.
             if self.kwargs['{}_const'.format(par)] is not None:
-                N += 1
-                continue
+                if self.kwargs['{}_const'.format(par)]:
+                    N += 1
+                    continue
 
             func = self.kwargs['{}_func'.format(par)]
             is_func = func is not None

--- a/micro21cm/inference.py
+++ b/micro21cm/inference.py
@@ -105,7 +105,7 @@ _priors_Q_pl = {'p0': (0, 1), 'p1': (-20, 0)}
 _priors_Q = {'tanh': _priors_Q_tanh, 'bpl': _priors_Q_bpl,
     'broad': _priors_broad['Q'], 'pl': _priors_Q_pl}
 
-_priors_R_pl = {'p0': (0, 30), 'p1': (0, 5)}
+_priors_R_pl = {'p0': (0, 100), 'p1': (0, 10)}
 _priors_R = {'pl': _priors_R_pl, 'broad': _priors_broad['R']}
 
 _priors_s_pl = {'p0': (0.0, 1), 'p1': (-2, 2)}

--- a/micro21cm/inference.py
+++ b/micro21cm/inference.py
@@ -171,7 +171,7 @@ fit_kwargs = \
 
  'bubbles_ion': 'ion',      # or 'hot' or False
  'bubbles_pdf': 'lognormal',
- 'include_rsd': 2,
+ 'include_rsd': 1,
 
  'restart': True,
  'burn': 0,

--- a/micro21cm/inference.py
+++ b/micro21cm/inference.py
@@ -44,8 +44,8 @@ _priors_broad = \
 {
  'Ts': (1e-2, 1000.),
  'Q': (0, 1),
- 'R': (0, 100),
- 'sigma': (0.05, 2.5),
+ 'R': (0.5, 50),
+ 'sigma': (0.25, 2.5),
  'gamma': (-4, 0),
  'Asys': (0.5, 1.5),
 }
@@ -105,7 +105,7 @@ _priors_Q_pl = {'p0': (0, 1), 'p1': (-20, 0)}
 _priors_Q = {'tanh': _priors_Q_tanh, 'bpl': _priors_Q_bpl,
     'broad': _priors_broad['Q'], 'pl': _priors_Q_pl}
 
-_priors_R_pl = {'p0': (0, 100), 'p1': (0, 10)}
+_priors_R_pl = {'p0': (0.5, 50), 'p1': (0, 10)}
 _priors_R = {'pl': _priors_R_pl, 'broad': _priors_broad['R']}
 
 _priors_s_pl = {'p0': (0.0, 1), 'p1': (-2, 2)}

--- a/micro21cm/models.py
+++ b/micro21cm/models.py
@@ -96,7 +96,7 @@ class BubbleModel(object):
             integral that averages the 3-D power spectrum over \mu.
         include_cross_terms : bool, int
             If > 0, will allow terms involving both ionization and density to
-            be non-zero. See Section 2.4 in Mirocha, Munoz et al. (2021) for
+            be non-zero. See Section 2.4 in Mirocha, Munoz et al. (2022) for
             details.
         effective_grid : bool
             When determining the mean bubble density, we smooth the density

--- a/tests/test_models_limiting_behaviour.py
+++ b/tests/test_models_limiting_behaviour.py
@@ -28,5 +28,35 @@ def test(z=8):
     assert np.allclose(kw['Q']**2, P1[-1]+P2[-1], rtol=0, atol=1e-3)
     assert np.allclose(kw['Q'] * (1. - kw['Q']), P_bn[-1], rtol=0, atol=1e-3)
 
+    # Need ionization fluctuations to vanish at Q==1
+    bb = model.get_bb(z, Q=1)
+    bn = model.get_bn(z, Q=1)
+    assert np.all(bb == 1)
+    assert np.all(bn == 0)
+
+    # Need cross-term cancellation when Q==1
+    dd = model.get_dd(z)
+    bd, bbd, bdd, bbdd, bbd_1pt, bd_1pt = model.get_cross_terms(z, Q=1,
+        separate=True)
+
+    assert np.all(bd == 0)
+    assert np.all(bdd + bbdd + dd == 0)
+    assert np.all(bbd == 0)
+    assert np.all(bbd_1pt == 0)
+    assert np.all(bd_1pt == 0)
+
+    # Need 21-cm fluctuations to vanish at Q==1
+    karr = np.logspace(-1, 0, 11)
+    D_21 = np.inf * np.ones_like(karr)
+    for Q in [0.98, 0.99, 0.999, 1]:
+        D_21_new = model.get_ps_21cm(z=z, k=karr, Q=Q) * karr**3 / 2. / np.pi**2
+
+        print(Q)
+        print(D_21)
+        print(D_21_new)
+
+        #assert np.all(D_21_new < D_21)
+        D_21 = D_21_new.copy()
+
 if __name__ == '__main__':
     test()

--- a/tests/test_models_ps_crossterms.py
+++ b/tests/test_models_ps_crossterms.py
@@ -26,7 +26,6 @@ karr = np.logspace(-1, 0., 41)
 def test():
 
     model = micro21cm.BubbleModel(**setup_kw)
-    model_3 = micro21cm.BubbleModel(include_cross_terms=3, **setup_kw)
     model_bin = micro21cm.BubbleModel(include_cross_terms=2, **setup_kw)
     model_1 = micro21cm.BubbleModel(include_cross_terms=1, **setup_kw)
     model_ideal = micro21cm.BubbleModel(include_cross_terms=0, **setup_kw)
@@ -37,7 +36,6 @@ def test():
     all_terms = model_bin.get_cross_terms(z, separate=False, **kwargs)
     assert np.allclose(other+bd, all_terms)
 
-    all_terms3 = model_3.get_cross_terms(z, separate=False, **kwargs)
     all_terms2 = model_ideal.get_cross_terms(z, separate=False, **kwargs)
     all_terms1 = model_1.get_cross_terms(z, separate=False, **kwargs)
 


### PR DESCRIPTION
This fixes a problem with limiting behaviour in the current version of the code, that 21-cm fluctuations don't vanish as Q->1. Long story short: one cannot neglect the <bdd'> and <bb'dd'> terms in the 21-cm correlation function.  See Section 2.4 in final paper (not up yet) for details.